### PR TITLE
Added Caching and url prefix option

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Mohamed Kamal Kamaly
+Copyright (c) 2014 Mohamed Kamal Kamaly, David Eberlein
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -25,3 +25,24 @@ relativePathsInPartial uses angular.element (jqLite and doesn't depend on JQuery
 # How to use
 
 just include the "relative-paths-in-partial.js" and add a dependency on "relativePathsInPartial" module.
+
+# Configuring a URL prefix
+You can configure a URL prefix to restrict the replacements be to only done to HTML files which URLs start with the given prefix.
+This can be done using the ```relativePathsInterceptorProvider``` in your ```module.configure()``` function.
+This functionality requires the support of String.startsWith or a polyfill (e.g. https://github.com/MathRobin/string.startsWith)
+
+Example
+
+```javascript
+angular.module('myApp', ['relativePathsInPartial'])
+.config(['relativePathsInterceptorProvider', function (relativePathsInterceptorProvider) {
+  relativePathsInterceptorProvider.setInteceptionPrefix('/intercept/urls/');
+  // other setup
+});
+```
+
+This will result in all html files starting with the URLs ```'/intercept/urls/'``` to be intercepted:
+- ```'/intercept/urls/myhtml.html'``` --> intercepted
+- ```'/intercept/urls/subdir/myhtml.html'``` --> intercepted
+- ```'/templates/urls/other.html'``` --> not intercepted (other prefix)
+- ```'/intercept/urls/subdir/myhtml'``` --> not intercepted (no .html extention)

--- a/relative-paths-in-partial.js
+++ b/relative-paths-in-partial.js
@@ -179,9 +179,9 @@ angular.module('relativePathsInPartial', [])
                 }
             };
         })
-        .config(function ($httpProvider) {
+        .config(["$httpProvider", function ($httpProvider) {
             $httpProvider.interceptors.push("relativePathsInterceptor");
-        });
+        }]);
 
 
 })();


### PR DESCRIPTION
- Fixed bug re-adding prefix if the url is relative
- Added option to set a url prefix to limit the scope of urls to apply the replacement to.
- Added check if the replacment has already been done boosting performance by only doing the replacements once per requested data. (Dynamic content of a url is supported since the check is not only based on the URL but also on a hash of the data.)
